### PR TITLE
Add TourCategories for Chips

### DIFF
--- a/src/tour/TourCategory.js
+++ b/src/tour/TourCategory.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withStyles } from '@material-ui/core/styles';
+import Avatar from '@material-ui/core/Avatar';
+import Chip from '@material-ui/core/Chip';
+import FaceIcon from '@material-ui/icons/Face';
+import DoneIcon from '@material-ui/icons/Done';
+
+const styles = theme => ({
+  root: {
+    // display: 'flex',
+    // justifyContent: 'center',
+    // flexWrap: 'wrap',
+  },
+  chip: {
+    margin: theme.spacing.unit,
+  },
+});
+
+  class TourCategory extends React.Component {
+    constructor(props) {
+      super(props);
+      this.state={
+         color: 'default',
+         active: 'none',
+      }
+    }    
+
+    ChipColor(position) {
+      if ( this.state.active === position) {
+        return "primary";
+      }
+      return "default";
+   }
+  
+    toggle(position){
+      if (this.state.active === position) {
+        this.setState({active : null})
+      } else {
+        this.setState({active : position})
+      }
+      // console.log(this.state.active);
+      this.props.handleCategory(this.state.active);
+  }
+
+  render  (){
+    const { classes } = this.props;
+    return (
+    <div className={classes.root}>
+      <Chip
+        label="Commerical" 
+        color={this.ChipColor('Commerical')}
+        onClick={() => {this.toggle('Commerical')}} 
+        className={classes.chip} 
+      />  
+      <Chip
+        label="Valunteer"  
+        color={this.ChipColor('Valunteer')}
+        onClick={() => {this.toggle('Valunteer')}} 
+        className={classes.chip} 
+      />  
+      <Chip
+        label="EcoTour"  
+        color={this.ChipColor('EcoTour')}
+        onClick={() => {this.toggle('EcoTour')}} 
+        className={classes.chip} 
+      />  
+    </div>
+    )
+  }
+}
+
+TourCategory.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles)(TourCategory);

--- a/src/tour/Tours.js
+++ b/src/tour/Tours.js
@@ -30,6 +30,7 @@ class Tours extends Component {
     this.handleChange = this.handleChange.bind(this)
     this.handleReset = this.handleReset.bind(this)
     this.handleApply = this.handleApply.bind(this)
+    this.handleCategory = this.handleCategory.bind(this)
   }
   
   handleClick(){
@@ -50,6 +51,9 @@ class Tours extends Component {
     let tourSection = document.querySelector('#tours') 
     smoothScroll(tourSection)
   }
+  handleCategory(category){
+    this.setState({category : category})
+  }
   
   componentWillMount(){
     this.props.dispatchFetchInitialTours()
@@ -62,6 +66,9 @@ class Tours extends Component {
     return (
       <div className={classes.tourWrapper} id='tours'>
         <Grid container spacing={16} className={classes.tourWrapper}>
+          <Grid item xs={12} md={12}>
+            <TourCategory handleCategory={this.handleCategory}/>
+          </Grid>
           { tours && tours.map((tour) => 
             ( ((localTourOpen && tour.type === 'local') || (customTourOpen && tour.type === 'custom') || (!localTourOpen && !customTourOpen))&& 
               <Grid item xs={12} sm={6} md={4} key={tour.id}>
@@ -78,6 +85,7 @@ class Tours extends Component {
 const styles = theme => ({
   tourWrapper: {
     padding: '5%',
+    'padding-top':'1%',
     flexGrow: 1,
   },
   [`@media (min-width: ${breakpoints['md']}px)`]:{


### PR DESCRIPTION
User flow:
1- When users open our website, users will see these Chips at the top of the tour list
2- By default, all Chips has grey color and users will see all tours
3- Users click on each chip, the chip color will be blue,
4- Users click on the blue chip,

Number 3 [ the tour list will be filtered by the selected type of tour], Number 4 [ it will cancel out all filters and the full tour list will be displayed.]
did not accomplish for reason the Tour.Type is no match 'Commerical,Valunteer,EcoTour' types.